### PR TITLE
Set .source to the full source when we emit an error using getSnippet.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,7 @@ export function transform ( source, options = {} ) {
 		});
 		options.jsx = jsx || options.jsx;
 	} catch (err) {
+		err.source = source;
 		err.snippet = getSnippet(source, err.loc);
 		err.toString = () => `${err.name}: ${err.message}\n${err.snippet}`;
 		throw err;

--- a/src/utils/CompileError.js
+++ b/src/utils/CompileError.js
@@ -21,6 +21,7 @@ export default class CompileError extends Error {
 		);
 
 		this.loc = loc;
+		this.source = source;
 		this.snippet = getSnippet(source, loc, node.end - node.start);
 	}
 


### PR DESCRIPTION
The yyx990803/buble fork of Bublé exists mostly for Vue template compilers
to call it over generated source code.  When it emits an error, that error
includes
  - .loc : the location in the generated source
  - .snippet : a snippet of the generated source
However, because the user doesn't have a copy of the generated code,
  - .loc is useless to them, and
  - if .snippet doesn't quite give the context that they need to identify
    the problem, then they are out of luck.

Sure, we could have the caller (vue-template-es2015-compiler, or its
callers: vue-loader/vueify/rollup-plugin-vue) catch the error, inject it
with .source (since it has the source passed to buble), and then throw it
again.  But let's solve it closer to the root, and reduce the possibility
of a mixup.

This also allows callers to do things like wrap our errors, replacing our
`getSnippet()`-generated `.snippet` with a `babel-code-frame`-generated
`.snippet`.
  - `getSnippet()` is OK, but on generated code (which is particularly
    gross), just "OK" often isn't good enough.  Let's give callers a chance
    to try to improve it.  babel-code-frame offers syntax highlighting,
    which makes things like missing quotes *way* easier to spot.
  - It doesn't have to be for quality reasons either; if all other error
    code snippets are formatted one way, let's give the caller a chance to
    format ours the same way, for UI consistency.