### PR TITLE
Environment variables in templates (`process.env.*`)

### DIFF
--- a/src/utils/globals.js
+++ b/src/utils/globals.js
@@ -3,6 +3,7 @@
 const names = 'Infinity,undefined,NaN,isFinite,isNaN,' +
   'parseFloat,parseInt,decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,' +
   'Math,Number,Date,Array,Object,Boolean,String,RegExp,Map,Set,JSON,Intl,' +
+  'process,' + // allow to use variables from `.env` file in templates (webpack define plugin)
   'require,' + // for webpack
   'arguments,' + // parsed as identifier but is a special keyword...
   '_h,_c' // cached to save property access (_c for ^2.1.5)


### PR DESCRIPTION
This change allows to use environment variables from `.env` file in templates via webpack define plugin.

Example: Vue app (via Vue CLI 3)

`.env` file:

```
VUE_APP_TITLE=My new site
```

I can use this variable in `template.html` file, but not in Vue component like (`App.vue`):

```js
<template>
    <h1>{{ process.env.VUE_APP_TITLE }}</h1>
</template>
```